### PR TITLE
チーム参加依頼/承認処理追加

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -95,7 +95,14 @@
                     <path d="M3 4a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm8 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V4zM3 12a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H4a1 1 0 01-1-1v-4zm8 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"/>
                   </svg>
                 </div>
-                <NuxtLink to="/" class="text-2xl font-bold text-gray-900 hover:text-gray-700 transition-colors">MatchMate</NuxtLink>
+                  <!--未ログイン時： トップページ-->
+                  <div v-if="!displayIsLoggedIn" class="flex gap-3">
+                    <NuxtLink to="/" class="text-2xl font-bold text-gray-900 hover:text-gray-700 transition-colors">MatchMate</NuxtLink>
+                  </div>
+                  <!--ログイン時： チームトップページ-->
+                  <nav v-else class="flex items-center gap-4">
+                    <NuxtLink to="/team_top" class="text-2xl font-bold text-gray-900 hover:text-gray-700 transition-colors">MatchMate</NuxtLink>
+                  </nav>
               </div>
               
               <!-- 未ログイン時：ログイン・新規登録ボタン -->
@@ -115,7 +122,7 @@
                   <NuxtLink to="/schedule" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
                     スケジュール
                   </NuxtLink>
-                  <NuxtLink to="/player/profile" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
+                  <NuxtLink to="/profile" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
                     プロフィール
                   </NuxtLink>
                   <button @click="handleLogout" class="px-3 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors">
@@ -128,10 +135,10 @@
                   <NuxtLink :to="{ path: '/schedule', query: { team_id: route.query.team_id } }" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
                     スケジュール
                   </NuxtLink>
-                  <NuxtLink to="/manager/teams" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
+                  <NuxtLink to="/profile" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
                     チーム管理
                   </NuxtLink>
-                  <NuxtLink to="/manager/players" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
+                  <NuxtLink to="/team_info" class="px-3 py-2 text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors">
                     選手管理
                   </NuxtLink>
                   <button @click="handleLogout" class="px-3 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors">

--- a/app/pages/team_join.vue
+++ b/app/pages/team_join.vue
@@ -1,244 +1,382 @@
 <template>
-    <div class="flex flex-col flex-1">
-      <main class="flex-1 p-8">
-        <div class="max-w-4xl mx-auto">
-          <!-- ヘッダー -->
-          <div class="mb-8 text-center">
-            <h1 class="text-3xl font-bold text-gray-900 mb-2">チームに参加</h1>
-            <p class="text-gray-600">参加コードを入力してチームに参加しましょう</p>
+  <div class="flex flex-col flex-1">
+    <main class="flex-1 p-8">
+      <div class="max-w-4xl mx-auto">
+        <!-- ヘッダー -->
+        <div class="mb-8 text-center">
+          <h1 class="text-3xl font-bold text-gray-900 mb-2">チームに参加</h1>
+          <p class="text-gray-600">参加したいチームを選択してください</p>
+        </div>
+
+        <!-- 未参加チーム一覧 -->
+        <div class="bg-white rounded-xl shadow-lg p-8 mb-8">
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">参加申請可能なチーム</h2>
+
+          <div v-if="loadingAvailableTeams" class="text-center py-8">
+            <p class="text-gray-500">読み込み中...</p>
           </div>
-  
-          <!-- 参加コード入力フォーム -->
-          <div class="bg-white rounded-xl shadow-lg p-8 mb-8">
-            <form @submit.prevent="handleJoinTeam" class="space-y-6">
-              <div>
-                <label for="joinCode" class="block text-sm font-medium text-gray-700 mb-2">
-                  参加コード <span class="text-red-500">*</span>
-                </label>
-                <input 
-                  id="joinCode"
-                  v-model="joinCode" 
-                  type="text"
-                  placeholder="例: ABC123"
-                  class="w-full px-4 py-3 border border-gray-300 rounded-lg text-lg focus:outline-none focus:ring-2 focus:ring-green-600 focus:border-transparent"
-                  required
-                />
-                <p class="text-xs text-gray-500 mt-2">※ 監督から共有された6桁の参加コードを入力してください</p>
-              </div>
-  
-              <!-- エラーメッセージ -->
-              <div v-if="error" class="p-4 bg-red-50 text-red-600 rounded-lg text-sm">
-                {{ error }}
-              </div>
-  
-              <!-- 成功メッセージ -->
-              <div v-if="success" class="p-4 bg-green-50 text-green-600 rounded-lg text-sm">
-                {{ success }}
-              </div>
-  
-              <!-- ボタン -->
-              <div class="flex gap-3">
-                <button 
-                  type="submit" 
-                  :disabled="loading || !joinCode"
-                  class="flex-1 px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-bold disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {{ loading ? '参加中...' : 'チームに参加' }}
-                </button>
-              </div>
-            </form>
+
+          <div v-else-if="availableTeams.length === 0" class="text-center py-8">
+            <div class="mb-4 text-6xl">✅</div>
+            <p class="text-gray-500">参加可能なチームがありません</p>
+            <p class="text-sm text-gray-400 mt-2">全てのチームに参加済みです</p>
           </div>
-  
-          <!-- 参加済みチーム一覧 -->
-          <div class="bg-white rounded-xl shadow-lg p-8">
-            <h2 class="text-2xl font-bold text-gray-900 mb-6">参加中のチーム</h2>
-  
-            <div v-if="loadingTeams" class="text-center py-8">
-              <p class="text-gray-500">読み込み中...</p>
-            </div>
-  
-            <div v-else-if="joinedTeams.length === 0" class="text-center py-8">
-              <div class="mb-4 text-6xl">⚽</div>
-              <p class="text-gray-500">まだチームに参加していません</p>
-              <p class="text-sm text-gray-400 mt-2">上記の参加コードを入力してチームに参加しましょう</p>
-            </div>
-  
-            <div v-else class="space-y-4">
-              <div 
-                v-for="team in joinedTeams" 
-                :key="team.team_id"
-                class="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+
+          <div v-else class="space-y-4">
+            <div 
+              v-for="team in availableTeams" 
+              :key="team.id"
+              class="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              <div class="flex items-center gap-4">
+                <!-- チームロゴ -->
+                <div class="w-16 h-16 rounded-lg overflow-hidden bg-gradient-to-br from-blue-400 to-blue-600 flex items-center justify-center flex-shrink-0">
+                  <img v-if="team.team_logo_url" :src="team.team_logo_url" :alt="team.team_name" class="w-full h-full object-cover" />
+                  <span v-else class="text-2xl text-white font-bold">{{ team.team_name?.charAt(0) || 'T' }}</span>
+                </div>
+                
+                <!-- チーム情報 -->
+                <div>
+                  <h3 class="font-bold text-gray-900 text-lg">{{ team.team_name || '不明なチーム' }}</h3>
+                  <p class="text-sm text-gray-600">{{ team.address }}</p>
+                </div>
+              </div>
+
+              <button
+                @click="handleJoinTeam(team)"
+                :disabled="joiningTeamId === team.id"
+                class="px-6 py-2 bg-blue-600 text-white text-sm font-bold rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <div class="flex items-center gap-4">
-                  <!-- チームロゴ -->
-                  <div class="w-16 h-16 rounded-lg overflow-hidden bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center flex-shrink-0">
-                    <img v-if="team.teams?.logo_url" :src="team.teams.logo_url" :alt="team.teams.team_name" class="w-full h-full object-cover" />
-                    <span v-else class="text-2xl text-white font-bold">{{ team.teams?.team_name?.charAt(0) || 'T' }}</span>
-                  </div>
+                {{ joiningTeamId === team.id ? '参加中...' : '参加する' }}
+              </button>
+            </div>
+          </div>
+
+          <!-- エラーメッセージ -->
+          <div v-if="error" class="mt-4 p-4 bg-red-50 text-red-600 rounded-lg text-sm">
+            {{ error }}
+          </div>
+
+          <!-- 成功メッセージ -->
+          <div v-if="success" class="mt-4 p-4 bg-green-50 text-green-600 rounded-lg text-sm">
+            {{ success }}
+          </div>
+        </div>
+
+        <!-- 参加済みチーム一覧 -->
+        <div class="bg-white rounded-xl shadow-lg p-8">
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">参加中のチーム</h2>
+
+          <div v-if="loadingJoinedTeams" class="text-center py-8">
+            <p class="text-gray-500">読み込み中...</p>
+          </div>
+
+          <div v-else-if="joinedTeams.length === 0" class="text-center py-8">
+            <div class="mb-4 text-6xl">⚽</div>
+            <p class="text-gray-500">まだチームに参加していません</p>
+            <p class="text-sm text-gray-400 mt-2">上記の参加可能なチームから選択してください</p>
+          </div>
+
+          <div v-else class="space-y-4">
+            <div 
+              v-for="team in joinedTeams" 
+              :key="team.team_id"
+              class="flex items-center justify-between p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              <div class="flex items-center gap-4 flex-1">
+                <!-- チームロゴ -->
+                <div class="w-16 h-16 rounded-lg overflow-hidden bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center flex-shrink-0">
+                  <img v-if="team.teams?.team_logo_url" :src="team.teams.team_logo_url" :alt="team.teams.team_name" class="w-full h-full object-cover" />
+                  <span v-else class="text-2xl text-white font-bold">{{ team.teams?.team_name?.charAt(0) || 'T' }}</span>
+                </div>
+                
+                <!-- チーム情報 -->
+                <div class="flex-1">
+                  <h3 class="font-bold text-gray-900 text-lg">{{ team.teams?.team_name || '不明なチーム' }}</h3>
+                  <p class="text-sm text-gray-600">参加日: {{ formatDate(team.created_at) }}</p>
                   
-                  <!-- チーム情報 -->
-                  <div>
-                    <h3 class="font-bold text-gray-900 text-lg">{{ team.teams?.team_name || '不明なチーム' }}</h3>
-                    <p class="text-sm text-gray-600">参加日: {{ formatDate(team.joined_at) }}</p>
+                  <!-- ステータスバッジ -->
+                  <div class="mt-2">
+                    <span 
+                      v-if="team.status === 'approved'"
+                      class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800"
+                    >
+                      ✓ 承認済み
+                    </span>
+                    <span 
+                      v-else-if="team.status === 'pending'"
+                      class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800"
+                    >
+                      ⏱ 承認待ち
+                    </span>
+                    <span 
+                      v-else-if="team.status === 'rejected'"
+                      class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-red-100 text-red-800"
+                    >
+                      ✕ 却下
+                    </span>
+                    <span 
+                      v-else
+                      class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-800"
+                    >
+                      ー 不明
+                    </span>
                   </div>
                 </div>
-  
-                <NuxtLink 
-                  :to="`/team_top?team_id=${team.team_id}`"
-                  class="px-4 py-2 bg-green-600 text-white text-sm font-bold rounded-lg hover:bg-green-700 transition-colors"
+              </div>
+              <div class="flex flex-col space-y-2">
+                <button
+                  v-if="team.status === 'rejected'"
+                  @click="handleRejoinTeam(team.team_id, team.teams?.team_name)"
+                  :disabled="rejoiningTeamId === team.team_id"
+                  class="px-4 py-2 bg-red-600 text-white text-sm font-bold rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  チームトップへ
-                </NuxtLink>
+                  {{ rejoiningTeamId === team.team_id ? '再申請中...' : '再申請' }}
+                </button>
+              <button
+                @click="selectTeam(team.team_id)"
+                :disabled="team.status !== 'approved'"
+                class="px-4 py-2 bg-green-600 text-white text-sm font-bold rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                チームトップへ
+              </button>
               </div>
             </div>
           </div>
         </div>
-      </main>
-    </div>
-  </template>
-  
-  <script setup lang="ts">
-  import { createClient } from '@supabase/supabase-js'
-  
-  const config = useRuntimeConfig()
-  const supabase = createClient(config.public.supabaseUrl, config.public.supabaseKey)
-  
-  const joinCode = ref('')
-  const loading = ref(false)
-  const loadingTeams = ref(true)
-  const error = ref('')
-  const success = ref('')
-  const joinedTeams = ref<any[]>([])
-  
-  // チーム参加処理
-  const handleJoinTeam = async () => {
-    if (!joinCode.value) return
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createClient } from '@supabase/supabase-js'
+
+const config = useRuntimeConfig()
+const supabase = createClient(config.public.supabaseUrl, config.public.supabaseKey)
+
+const availableTeams = ref<any[]>([])
+const joinedTeams = ref<any[]>([])
+const loadingAvailableTeams = ref(true)
+const loadingJoinedTeams = ref(true)
+const joiningTeamId = ref<string | null>(null)
+const rejoiningTeamId = ref<string | null>(null)
+const error = ref('')
+const success = ref('')
+
+// 未参加のチーム一覧を取得
+const fetchAvailableTeams = async () => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      loadingAvailableTeams.value = false
+      return
+    }
+
+    // 全チームを取得
+    const { data: allTeams, error: teamsError } = await supabase
+      .from('teams')
+      .select('id, team_name, team_logo_url, address, created_at')
+      .order('created_at', { ascending: false })
+
+    if (teamsError) {
+      console.error('Fetch teams error:', teamsError)
+      loadingAvailableTeams.value = false
+      return
+    }
+
+    // 参加済みのチームIDを取得
+    const { data: memberData, error: memberError } = await supabase
+      .from('team_members')
+      .select('team_id')
+      .eq('player_id', user.id)
+
+    if (memberError) {
+      console.error('Fetch member teams error:', memberError)
+    }
+
+    const joinedTeamIds = new Set(memberData?.map(m => m.team_id) || [])
+
+    // 未参加のチームのみをフィルタリング
+    availableTeams.value = (allTeams || []).filter(team => !joinedTeamIds.has(team.id))
+
+  } catch (err) {
+    console.error('Error:', err)
+  } finally {
+    loadingAvailableTeams.value = false
+  }
+}
+
+// 参加中のチーム一覧を取得（ステータス情報を含む）
+const fetchJoinedTeams = async () => {
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      loadingJoinedTeams.value = false
+      return
+    }
+
+    const { data, error: fetchError } = await supabase
+      .from('team_members')
+      .select(`
+        team_id,
+        created_at,
+        status,
+        teams (
+          id,
+          team_name,
+          team_logo_url
+        )
+      `)
+      .eq('player_id', user.id)
+      .order('created_at', { ascending: false })
+
+    if (fetchError) {
+      console.error('Fetch joined teams error:', fetchError)
+      loadingJoinedTeams.value = false
+      return
+    }
+
+    joinedTeams.value = data || []
+  } catch (err) {
+    console.error('Error:', err)
+  } finally {
+    loadingJoinedTeams.value = false
+  }
+}
+
+// チーム参加処理
+const handleJoinTeam = async (team: any) => {
+  joiningTeamId.value = team.id
+  error.value = ''
+  success.value = ''
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      error.value = 'ログインが必要です'
+      joiningTeamId.value = null
+      return
+    }
+
+    // チームメンバーに追加（ステータスはpendingで登録）
+    const { error: insertError } = await supabase
+      .from('team_members')
+      .insert({
+        team_id: team.id,
+        player_id: user.id,
+        status: 'pending',
+        created_at: new Date().toISOString()
+      })
+
+    if (insertError) {
+      // 既に参加している場合のエラーハンドリング
+      if (insertError.code === '23505') {
+        error.value = '既にこのチームに参加申請しています'
+      } else {
+        error.value = 'チームへの参加申請に失敗しました'
+      }
+      console.error('Insert error:', insertError)
+      joiningTeamId.value = null
+      return
+    }
+
+    // 成功
+    success.value = `${team.team_name}への参加申請を送信しました！承認をお待ちください。`
     
-    loading.value = true
-    error.value = ''
-    success.value = ''
-  
-    try {
-      // 現在のユーザーを取得
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) {
-        error.value = 'ログインが必要です'
-        loading.value = false
-        return
-      }
-  
-      // 参加コードでチームを検索
-      const { data: team, error: teamError } = await supabase
-        .from('teams')
-        .select('id, team_name')
-        .eq('join_code', joinCode.value.toUpperCase())
-        .single()
-  
-      if (teamError || !team) {
-        error.value = '参加コードが正しくありません'
-        console.error('Team search error:', teamError)
-        loading.value = false
-        return
-      }
-  
-      // 既に参加しているかチェック
-      const { data: existingMember } = await supabase
-        .from('team_members')
-        .select('id')
-        .eq('team_id', team.id)
-        .eq('user_id', user.id)
-        .single()
-  
-      if (existingMember) {
-        error.value = '既にこのチームに参加しています'
-        loading.value = false
-        return
-      }
-  
-      // チームメンバーに追加
-      const { error: insertError } = await supabase
-        .from('team_members')
-        .insert({
-          team_id: team.id,
-          user_id: user.id,
-          joined_at: new Date().toISOString()
-        })
-  
-      if (insertError) {
-        error.value = 'チームへの参加に失敗しました'
-        console.error('Insert error:', insertError)
-        loading.value = false
-        return
-      }
-  
-      // 成功
-      success.value = `${team.team_name}に参加しました！`
-      joinCode.value = ''
-      
-      // チーム一覧を再取得
-      await fetchJoinedTeams()
-  
-      // 3秒後にチームトップに遷移
-      setTimeout(() => {
-        navigateTo({ path: '/team_top', query: { team_id: team.id } })
-      }, 2000)
-  
-    } catch (err) {
-      error.value = 'エラーが発生しました'
-      console.error('Join team error:', err)
-    } finally {
-      loading.value = false
+    // 一覧を再取得
+    await Promise.all([
+      fetchAvailableTeams(),
+      fetchJoinedTeams()
+    ])
+
+  } catch (err) {
+    error.value = 'エラーが発生しました'
+    console.error('Join team error:', err)
+  } finally {
+    joiningTeamId.value = null
+  }
+}
+
+// チーム再申請処理 (rejected -> pending)
+const handleRejoinTeam = async (teamId: string, teamName: string) => {
+  rejoiningTeamId.value = teamId
+  error.value = ''
+  success.value = ''
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      error.value = 'ログインが必要です'
+      rejoiningTeamId.value = null
+      return
     }
-  }
-  
-  // 参加中のチーム一覧を取得
-  const fetchJoinedTeams = async () => {
-    try {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) return
-  
-      const { data, error: fetchError } = await supabase
-        .from('team_members')
-        .select(`
-          team_id,
-          joined_at,
-          teams (
-            id,
-            team_name,
-            logo_url
-          )
-        `)
-        .eq('user_id', user.id)
-        .order('joined_at', { ascending: false })
-  
-      if (fetchError) {
-        console.error('Fetch teams error:', fetchError)
-        return
-      }
-  
-      joinedTeams.value = data || []
-    } catch (err) {
-      console.error('Error:', err)
-    } finally {
-      loadingTeams.value = false
+
+    // team_membersのステータスをpendingに更新
+    const { error: updateError } = await supabase
+      .from('team_members')
+      .update({ 
+        status: 'pending',
+        // 再申請の日時を更新したい場合は、updated_atなどを設定できます
+      })
+      .eq('team_id', teamId)
+      .eq('player_id', user.id)
+
+    if (updateError) {
+      error.value = 'チームへの再申請に失敗しました'
+      console.error('Update error:', updateError)
+      rejoiningTeamId.value = null
+      return
     }
-  }
-  
-  // 日付フォーマット
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`
-  }
-  
-  // ページ読み込み時に実行
-  onMounted(async () => {
+
+    // 成功
+    success.value = `${teamName || 'チーム'}への参加を再申請しました！承認をお待ちください。`
+
+    // 一覧を再取得
     await fetchJoinedTeams()
-  })
-  
-  useHead({
-    title: 'MatchMate - チーム参加',
-    meta: [
-      { name: 'description', content: 'チームに参加' }
-    ]
-  })
-  </script>
+
+  } catch (err) {
+    error.value = 'エラーが発生しました'
+    console.error('Rejoin team error:', err)
+  } finally {
+    rejoiningTeamId.value = null
+  }
+}
+// チームトップへ遷移（承認済みのみ）
+const selectTeam = async (teamId: string) => {
+  try {
+    const { setTeamId } = useTeamSession()
+    const success = await setTeamId(teamId)
+    
+    if (success) {
+      await navigateTo('/team_info')
+    } else {
+      error.value = 'チーム情報の保存に失敗しました'
+    }
+  } catch (err) {
+    console.error('Select team error:', err)
+    error.value = 'エラーが発生しました'
+  }
+}
+
+// 日付フォーマット
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString)
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`
+}
+
+// ページ読み込み時に実行
+onMounted(async () => {
+  await Promise.all([
+    fetchAvailableTeams(),
+    fetchJoinedTeams()
+  ])
+})
+
+useHead({
+  title: 'MatchMate - チーム参加',
+  meta: [
+    { name: 'description', content: 'チームに参加' }
+  ]
+})
+</script>

--- a/app/pages/team_select.vue
+++ b/app/pages/team_select.vue
@@ -11,17 +11,31 @@
               </p>
             </div>
             
-            <!-- 監督専用：チーム新規作成ボタン -->
-            <NuxtLink 
-              v-if="isManager" 
-              to="/manager/teams/create"
-              class="px-4 py-2 bg-green-600 text-white text-sm font-bold rounded-lg hover:bg-green-700 transition-colors shadow-lg flex items-center gap-2"
-            >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-              </svg>
-              チームを新規作成
-            </NuxtLink>
+            <div class="flex gap-3">
+              <!-- 選手専用：チームに参加ボタン -->
+              <button
+                v-if="!isManager"
+                @click="navigateTo('/team_join')"
+                class="px-4 py-2 bg-blue-600 text-white text-sm font-bold rounded-lg hover:bg-blue-700 transition-colors shadow-lg flex items-center gap-2"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
+                </svg>
+                チームに参加
+              </button>
+
+              <!-- 監督専用：チーム新規作成ボタン -->
+              <NuxtLink 
+                v-if="isManager" 
+                to="/manager/teams/create"
+                class="px-4 py-2 bg-green-600 text-white text-sm font-bold rounded-lg hover:bg-green-700 transition-colors shadow-lg flex items-center gap-2"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                </svg>
+                チームを新規作成
+              </NuxtLink>
+            </div>
           </div>
           
           <div class="space-y-4">
@@ -170,17 +184,18 @@ const handleTeamSelect = async (team: any) => {
   })
 }
   
-  useHead({
-    title: 'MatchMate - チーム選択',
-    meta: [
-      { name: 'description', content: 'MatchMateチーム選択' }
-    ]
-  })
-  const { setTeamId } = useTeamSession()
+useHead({
+  title: 'MatchMate - チーム選択',
+  meta: [
+    { name: 'description', content: 'MatchMateチーム選択' }
+  ]
+})
+
+const { setTeamId } = useTeamSession()
 
 const selectTeam = async (team: any) => {
-    const user = await sessionFromUserData();
-    console.log(user)
+  const user = await sessionFromUserData();
+  console.log(user)
   try {
     
     if (!user) {
@@ -201,4 +216,4 @@ const selectTeam = async (team: any) => {
     throw new Error('チーム選択処理でエラーが発生しました')
   }
 }
-  </script>
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8331,13 +8331,14 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/comment-parser": {
@@ -17233,6 +17234,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/svgo/node_modules/css-tree": {


### PR DESCRIPTION
変更点①
承認済み(approved)の場合は、チームトップ画面に遷移できるように、しています。
承認待ちは、表示のみ(アクション不可)
却下(rejected)の場合は再申請できるようにしています。
チーム参加(team_join.vue)画面にて参加可能なチームと参加中のチームが表示されるようにしています。 各チームへの申請状態(team_members/status)が表示されるようにしてます。

変更点②
選手がチーム参加依頼を投げた後、監督側で承認および却下処理を行えるようにしています。
承認時、team_membersテーブルのstatusをapprovedに、却下時rejectedに変更した後、リストを再取得するようにしています。

変更点③
ヘッダーのMatchmate、スケジュール、チーム管理、選手管理を押下した時の遷移先を設定しました。 Matchmate押下⇒team_top.vueに遷移。
スケジュール押下⇒schedule.vueに遷移。
チーム管理⇒profile.vueに遷移。
選手管理⇒team_info.vueに遷移。